### PR TITLE
handling single-quote imports

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,20 +5,6 @@ Please check if your PR fulfills the following requirements:
 - [ ] Tests for the changes have been added (for bug fixes / features)
 - [ ] Docs have been added / updated (for bug fixes / features)
 
-## PR Type
-
-What kind of change does this PR introduce?
-
-<!-- Please check the one that applies to this PR using "x". -->
-
-- [ ] Bugfix
-- [ ] Feature
-- [ ] Code style update (formatting, local variables)
-- [ ] Refactoring (no functional changes, no api changes)
-- [ ] Build related changes
-- [ ] CI related changes
-- [ ] Other... Please describe:
-
 ## What is the current behavior?
 
 ...
@@ -27,9 +13,6 @@ What kind of change does this PR introduce?
 
 ...
 
-## Does this PR introduce a breaking change?
-
-- [ ] Yes
-- [ ] No
-
 ## Other information
+
+...

--- a/lib/build-tools/build-tool.interface.ts
+++ b/lib/build-tools/build-tool.interface.ts
@@ -15,7 +15,7 @@ export interface IBuildTool {
   /**
    * Interrupt tool's execution
    */
-  abord(): Promise<void>;
+  abort(): Promise<void>;
 
   isAborted(): boolean;
 

--- a/lib/build-tools/build-tool.ts
+++ b/lib/build-tools/build-tool.ts
@@ -13,7 +13,7 @@ export class BuildTool implements IBuildTool {
     throw new Error('Method not implemented.');
   }
 
-  async abord(): Promise<void> {
+  async abort(): Promise<void> {
     this.aborted = true;
   }
 

--- a/lib/build-tools/build-tools.mocks.ts
+++ b/lib/build-tools/build-tools.mocks.ts
@@ -4,7 +4,7 @@ import { BuildTool } from './build-tool';
 export class BuildToolsMock extends BuildTool implements IBuildTool {
   override async execute() {}
 
-  override async abord() {
+  override async abort() {
     this.aborted = true;
   }
 

--- a/lib/build-tools/paths-resolver/paths-resolver.spec.ts
+++ b/lib/build-tools/paths-resolver/paths-resolver.spec.ts
@@ -12,6 +12,7 @@ describe('PathsResolver', () => {
   tscRunnerOptions.outDir = '/app/dist';
   const compiledFile = `
     const tsc_builder_1 = require("@executors/tsc-builder");
+    const tsc_builder_2 = require('@executors/tsc-builder');
     const tsc_watcher_1 = require("@executors/tsc-watcher");
   `;
   const pathToFile = tscRunnerOptions.outDir + '/server/index.js';
@@ -59,6 +60,7 @@ describe('PathsResolver', () => {
       });
 
       expect(result).toContain('../libs/tsc-builder/src/index.js');
+      expect(result).not.toContain("require('@executors/tsc-builder')");
       expect(result).not.toContain('require("@executors/tsc-builder")');
     });
 

--- a/lib/build-tools/paths-resolver/paths-resolver.ts
+++ b/lib/build-tools/paths-resolver/paths-resolver.ts
@@ -16,8 +16,8 @@ export class PathsResolver extends BuildTool implements IBuildTool {
     }
   }
 
-  override abord() {
-    return super.abord();
+  override abort() {
+    return super.abort();
   }
 
   override cleanup() {}
@@ -34,6 +34,8 @@ export class PathsResolver extends BuildTool implements IBuildTool {
     const value = this.options.paths[args.pathKey][0].replace(/.ts$/, '.js');
     const absolutePath = join(this.options.outDir, value);
     const relativePath = relative(dirname(args.filePath), absolutePath).replace(/\\/g, '/');
-    return args.file.replace(new RegExp(`"${args.pathKey}"`, 'g'), `"${relativePath}"`);
+    return args.file
+      .replace(new RegExp(`'${args.pathKey}'`, 'g'), `'${relativePath}'`)
+      .replace(new RegExp(`"${args.pathKey}"`, 'g'), `"${relativePath}"`);
   }
 }

--- a/lib/build-tools/project-builder.ts
+++ b/lib/build-tools/project-builder.ts
@@ -21,8 +21,8 @@ export class ProjectBuilder extends BuildTool implements IBuildTool {
     });
   }
 
-  override async abord() {
-    await super.abord();
+  override async abort() {
+    await super.abort();
     try {
       this.buildProcess.kill();
       await new Promise<void>((resolve) => this.buildProcess.on('exit', () => resolve()));

--- a/lib/build-tools/project-cleaner.ts
+++ b/lib/build-tools/project-cleaner.ts
@@ -10,8 +10,8 @@ export class ProjectCleaner extends BuildTool implements IBuildTool {
     }
   }
 
-  override async abord() {
-    await super.abord();
+  override async abort() {
+    await super.abort();
   }
 
   override cleanup() {}

--- a/lib/executors/tsc-executor.ts
+++ b/lib/executors/tsc-executor.ts
@@ -54,7 +54,7 @@ export abstract class TscExecutor {
     if (this.options.isVerbose) {
       console.info('\x1b[33m%s\x1b[0m', `[nx-tsc] Abording ${this.runningTool.constructor.name}...`);
     }
-    return this.runningTool.abord();
+    return this.runningTool.abort();
   }
 
   private async runTool(tool: typeof BuildTool) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@matii96/nx-tsc",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@matii96/nx-tsc",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint:fix": "eslint ./lib/**/*.ts --fix",
     "test": "jest",
     "test:cov": "jest --coverage",
-    "test:e2e": "docker-compose -f ./e2e/docker-compose.e2e.yml up --abort-on-container-exit --exit-code-from healthcheck --build --remove-orphans"
+    "test:e2e": "docker compose -f ./e2e/docker-compose.e2e.yml up --abort-on-container-exit --exit-code-from healthcheck --build --remove-orphans"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matii96/nx-tsc",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "tsc executor for nx",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## What is the current behavior?

Imports with single quote eg. `require('@executors/tsc-builder')` aren't resolved into relative paths.

## What is the new behavior?

Added resolving same as for double quotes. 

